### PR TITLE
add Ubuntu 20.04 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Ubuntu 20.04 support
+
 ### Changed
 ### Removed
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 
-stackdriver_distro_codename: "xenial"
-stackdriver_repo_url: "http://repo.stackdriver.com/apt"
-stackdriver_pubkey_url: "https://app.stackdriver.com/RPM-GPG-KEY-stackdriver"
+stackdriver_repo_url: "https://packages.cloud.google.com/apt"
+stackdriver_xenial_repo_url: "http://repo.stackdriver.com/apt"
+stackdriver_pubkey_url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+stackdriver_xenial_pubkey_url: "https://app.stackdriver.com/RPM-GPG-KEY-stackdriver"
 
 # override to furnish custom config template
 stackdriver_agent_config: "stackdriver-agent"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,6 +7,12 @@
         update_cache: yes
         cache_valid_time: 3600
 
+    - name: "Install deps"
+      apt:
+        name:
+          - gpg-agent # for some reason we need to add this for 20.04 on github
+      when: ansible_distribution_release != "xenial"
+        
     - name: "Include stackdriver_role"
       include_role:
         name: "stackdriver_role"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: docker
 platforms:
-  # - name: ubuntu2004
-  #   image: geerlingguy/docker-ubuntu2004-ansible
-  #   pre_build_image: True
+  - name: ubuntu2004
+    image: geerlingguy/docker-ubuntu2004-ansible
+    pre_build_image: True
   - name: ubuntu1604
     image: geerlingguy/docker-ubuntu1604-ansible
     pre_build_image: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,28 @@
 
 - name: Add Stackdriver public key
   apt_key: url={{ stackdriver_pubkey_url }} state=present
+  when: ansible_distribution_release != "xenial"
   tags: ['stackdriver', 'stackdriver:install']
 
 - name: Add Stackdriver repository
   apt_repository: >
-    repo="deb {{ stackdriver_repo_url }} {{ stackdriver_distro_codename }} main"
+    repo="deb {{ stackdriver_repo_url }} google-cloud-monitoring-{{ ansible_distribution_release }}-all main"
     update_cache=yes
+  when: ansible_distribution_release != "xenial"
+  tags: ['stackdriver', 'stackdriver:install']
+
+# xenial uses a different repo + key
+- name: Add Stackdriver public key
+  apt_key: url={{ stackdriver_xenial_pubkey_url }} state=present
+  when: ansible_distribution_release == "xenial"
+  tags: ['stackdriver', 'stackdriver:install']
+
+# xenial uses a different repo + key
+- name: Add Stackdriver repository
+  apt_repository: >
+    repo="deb {{ stackdriver_xenial_repo_url }} {{ ansible_distribution_release }} main"
+    update_cache=yes
+  when: ansible_distribution_release == "xenial"
   tags: ['stackdriver', 'stackdriver:install']
 
 - name: Install Stackdriver agent


### PR DESCRIPTION
slightly tricky as it appears they switched to a different repo location and name.

Since we should be moving off of 16.04/Xenial, I basically added some special case variables and tasks for xenial. Those will be easy to just delete once we are no longer supporting Xenial.
